### PR TITLE
Convert Objects to DateTime for DateTime Functions

### DIFF
--- a/LinqToQuerystring/TreeNodes/Functions/DayNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/DayNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type) && !typeof(DateTimeOffset).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "day");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Day");

--- a/LinqToQuerystring/TreeNodes/Functions/DaysNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/DaysNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "days");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Day");

--- a/LinqToQuerystring/TreeNodes/Functions/HourNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/HourNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type) && !typeof(DateTimeOffset).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "hour");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Hour");

--- a/LinqToQuerystring/TreeNodes/Functions/HoursNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/HoursNode.cs
@@ -22,7 +22,7 @@ namespace LinqToQuerystring.TreeNodes.Functions
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "hours");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Hour");

--- a/LinqToQuerystring/TreeNodes/Functions/MinuteNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/MinuteNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type) && !typeof(DateTimeOffset).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "minute");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Minute");

--- a/LinqToQuerystring/TreeNodes/Functions/MinutesNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/MinutesNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "minutes");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Minute");

--- a/LinqToQuerystring/TreeNodes/Functions/MonthNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/MonthNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "month");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Month");

--- a/LinqToQuerystring/TreeNodes/Functions/SecondNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/SecondNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type) && !typeof(DateTimeOffset).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "second");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Second");

--- a/LinqToQuerystring/TreeNodes/Functions/SecondsNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/SecondsNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "seconds");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Second");

--- a/LinqToQuerystring/TreeNodes/Functions/YearNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/YearNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type) && !typeof(DateTimeOffset).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "year");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Year");

--- a/LinqToQuerystring/TreeNodes/Functions/YearsNode.cs
+++ b/LinqToQuerystring/TreeNodes/Functions/YearsNode.cs
@@ -22,7 +22,7 @@
 
             if (!typeof(DateTime).IsAssignableFrom(childexpression.Type))
             {
-                throw new FunctionNotSupportedException(childexpression.Type, "years");
+                childexpression = Expression.Convert(childexpression, typeof(DateTime));
             }
 
             return Expression.Property(childexpression, "Year");


### PR DESCRIPTION
Updated to attempt to convert the target object to a datetime before applying a datetime function. Issue #53.