### PR TITLE
Decoded URL in LinqToQueryableAttribute.

### DIFF
--- a/LinqToQuerystring.WebApi/LinqToQueryableAttribute.cs
+++ b/LinqToQuerystring.WebApi/LinqToQueryableAttribute.cs
@@ -4,8 +4,8 @@
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Formatting;
+    using System.Web;
     using System.Web.Http.Filters;
-
     using ActionFilterAttribute = System.Web.Http.Filters.ActionFilterAttribute;
 
     public class LinqToQueryableAttribute : ActionFilterAttribute
@@ -29,7 +29,7 @@
 
             if (originalquery != null)
             {
-                var queryString = actionExecutedContext.Request.RequestUri.Query;
+                var queryString = HttpUtility.UrlDecode(actionExecutedContext.Request.RequestUri.Query);
                 var genericType = originalquery.GetType().GetGenericArguments()[0];
 
                 var reply = originalquery.LinqToQuerystring(genericType, queryString, this.forceDynamicProperties, this.maxPageSize);

--- a/LinqToQuerystring.WebApi/LinqToQuerystring.WebApi.csproj
+++ b/LinqToQuerystring.WebApi/LinqToQuerystring.WebApi.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>

--- a/LinqToQuerystring.WebApi/LinqToQuerystring.WebApi2.csproj
+++ b/LinqToQuerystring.WebApi/LinqToQuerystring.WebApi2.csproj
@@ -45,6 +45,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.0.0\lib\net45\System.Web.Http.dll</HintPath>


### PR DESCRIPTION
Decoded URL in LinqToQueryableAttribute. This fixes issues with encoded urls. Fixes #36 and #51.